### PR TITLE
User can add a payment type

### DIFF
--- a/Bangazon/Areas/Identity/IdentityHostingStartup.cs
+++ b/Bangazon/Areas/Identity/IdentityHostingStartup.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Bangazon.Data;
+using Bangazon.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: HostingStartup(typeof(Bangazon.Areas.Identity.IdentityHostingStartup))]
+namespace Bangazon.Areas.Identity
+{
+    public class IdentityHostingStartup : IHostingStartup
+    {
+        public void Configure(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices((context, services) => {
+            });
+        }
+    }
+}

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Bangazon.Areas.Identity.Pages.Account.Manage
+{
+    public static class ManageNavPages
+    {
+        public static string Index => "Index";
+
+        public static string ChangePassword => "ChangePassword";
+
+        public static string ExternalLogins => "ExternalLogins";
+
+        public static string PersonalData => "PersonalData";
+
+        public static string TwoFactorAuthentication => "TwoFactorAuthentication";
+
+        public static string IndexNavClass(ViewContext viewContext) => PageNavClass(viewContext, Index);
+
+        public static string ChangePasswordNavClass(ViewContext viewContext) => PageNavClass(viewContext, ChangePassword);
+
+        public static string ExternalLoginsNavClass(ViewContext viewContext) => PageNavClass(viewContext, ExternalLogins);
+
+        public static string PersonalDataNavClass(ViewContext viewContext) => PageNavClass(viewContext, PersonalData);
+
+        public static string TwoFactorAuthenticationNavClass(ViewContext viewContext) => PageNavClass(viewContext, TwoFactorAuthentication);
+
+        private static string PageNavClass(ViewContext viewContext, string page)
+        {
+            var activePage = viewContext.ViewData["ActivePage"] as string
+                ?? System.IO.Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
+            return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "active" : null;
+        }
+    }
+}

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/_Layout.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/_Layout.cshtml
@@ -1,0 +1,22 @@
+﻿@{
+    Layout = "/Areas/Identity/Pages/_Layout.cshtml";
+}
+
+<h1>Manage your account</h1>
+
+<div>
+    <h4>Change your account settings</h4>
+    <hr />
+    <div class="row">
+        <div class="col-md-3">
+            <partial name="_ManageNav" />
+        </div>
+        <div class="col-md-9">
+            @RenderBody()
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @RenderSection("Scripts", required: false)
+}

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
@@ -11,5 +11,5 @@
         }
         <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication">Two-factor authentication</a></li>
         <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData">Personal data</a></li>
-        <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="payment-types" asp-controller="PaymentTypes" asp-action="Index">See Payment Types</a></li>
+        <li class="nav-item"><a class="nav-link" id="payment-types" asp-controller="PaymentTypes" asp-action="Index">See Payment Types</a></li>
     </ul>

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
@@ -1,0 +1,15 @@
+﻿@inject SignInManager<ApplicationUser> SignInManager
+@{
+    var hasExternalLogins = (await SignInManager.GetExternalAuthenticationSchemesAsync()).Any();
+}
+    <ul class="nav nav-pills flex-column">
+        <li class="nav-item"><a class="nav-link @ManageNavPages.IndexNavClass(ViewContext)" id="profile" asp-page="./Index">Profile</a></li>
+        <li class="nav-item"><a class="nav-link @ManageNavPages.ChangePasswordNavClass(ViewContext)" id="change-password" asp-page="./ChangePassword">Password</a></li>
+        @if (hasExternalLogins)
+        {
+            <li id="external-logins" class="nav-item"><a id="external-login" class="nav-link @ManageNavPages.ExternalLoginsNavClass(ViewContext)" asp-page="./ExternalLogins">External logins</a></li>
+        }
+        <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication">Two-factor authentication</a></li>
+        <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData">Personal data</a></li>
+        <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="payment-types" asp-controller="PaymentTypes" asp-action="Index">See Payment Types</a></li>
+    </ul>

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/_ViewImports.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+﻿@using Bangazon.Areas.Identity.Pages.Account.Manage

--- a/Bangazon/Bangazon.csproj
+++ b/Bangazon/Bangazon.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -6,16 +6,18 @@
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Remove="Models\ProductTypeViewModels\**" />
+    <Content Remove="Models\ProductTypeViewModels\**" />
+    <EmbeddedResource Remove="Models\ProductTypeViewModels\**" />
+    <None Remove="Models\ProductTypeViewModels\**" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
-  </ItemGroup>
-
-
-  <ItemGroup>
-    <Folder Include="Models\ProductTypeViewModels\" />
   </ItemGroup>
 
 </Project>

--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -7,10 +7,11 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using Bangazon.Data;
 using Bangazon.Models;
-
+using Microsoft.AspNetCore.Authorization;
 
 namespace Bangazon.Controllers
 {
+    [Authorize]
     public class ProductTypesController : Controller
     {
         private readonly ApplicationDbContext _context;

--- a/Bangazon/Models/PaymentType.cs
+++ b/Bangazon/Models/PaymentType.cs
@@ -22,6 +22,7 @@ namespace Bangazon.Models
 
     [Required]
     [StringLength(20)]
+    [Display(Name = "Account Number")]
     public string AccountNumber { get; set; }
 
     [Required]

--- a/Bangazon/Views/PaymentTypes/Create.cshtml
+++ b/Bangazon/Views/PaymentTypes/Create.cshtml
@@ -6,7 +6,7 @@
 
 <h1>Create</h1>
 
-<h4>PaymentType</h4>
+<h4>Payment Type</h4>
 <hr />
 <div class="row">
     <div class="col-md-4">
@@ -21,10 +21,6 @@
                 <label asp-for="AccountNumber" class="control-label"></label>
                 <input asp-for="AccountNumber" class="form-control" />
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="UserId" class="control-label"></label>
-                <select asp-for="UserId" class ="form-control" asp-items="ViewBag.UserId"></select>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/Bangazon/Views/PaymentTypes/Index.cshtml
+++ b/Bangazon/Views/PaymentTypes/Index.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Index";
 }
 
-<h1>Index</h1>
+<h1>Payment Types</h1>
 
 <p>
     <a asp-action="Create">Create New</a>
@@ -21,9 +21,6 @@
             <th>
                 @Html.DisplayNameFor(model => model.AccountNumber)
             </th>
-            <th>
-                @Html.DisplayNameFor(model => model.User)
-            </th>
             <th></th>
         </tr>
     </thead>
@@ -38,9 +35,6 @@
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.AccountNumber)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.User.Id)
             </td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.PaymentTypeId">Edit</a> |

--- a/Bangazon/Views/Shared/_LoginPartial.cshtml
+++ b/Bangazon/Views/Shared/_LoginPartial.cshtml
@@ -6,7 +6,7 @@
 @if (SignInManager.IsSignedIn(User))
 {
     <li class="nav-item">
-        <a  class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @User.Identity.Name!</a>
+        <a  class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Account Details</a>
     </li>
     <li class="nav-item">
         <form  class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">


### PR DESCRIPTION
User can add a payment type

# Description

This PR contains the code that allows the user to see a list of their payment types as well as create a new one.



Fixes Issue # [(6)](https://github.com/the-devastating-chickens/BangazonSite/issues/6)

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

1. `git fetch --all`
1. `git checkout cm-whoops`
1. Review the code in the PaymentTypesController and make sure it is well commented
1. Without being logged in, make sure you can't see payment types by typing `/PaymentTypes` into your browser
1. Also confirm you can't see product types without logging in
1. Log in to an account
1. Click on the user profile name on the top left
1. See that there is the `See Payment Types` link and click it
1. Make sure the list only contains the users payment types
1. Create a new payment type by clicking the link at the top of the index view



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works
