### PR TITLE
WEM max product price and no special characters

### DIFF
--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -17,13 +17,15 @@ namespace Bangazon.Models
         public DateTime DateCreated { get; set; }
 
         [Required]
-        [StringLength(255)]
+        [StringLength(255, ErrorMessage = "Please shorten the product title to 255 characters")]
+        // Billy Mitchell: This Regular Expression is used to forbid users from usings these !@#$%^&*() characters. Use allow: [characters in here] or not allow [^characters in here]
+        [RegularExpression(@"^[^!@#$%^&*()]+$", ErrorMessage = "The characters !@#$%^&*() are not allowed")]
         public string Description { get; set; }
 
         [Required]
+        [StringLength(55, ErrorMessage = "Please shorten the product title to 55 characters")]
         // Billy Mitchell: This Regular Expression is used to forbid users from usings these !@#$%^&*() characters. Use allow: [characters in here] or not allow [^characters in here]
         [RegularExpression(@"^[^!@#$%^&*()]+$", ErrorMessage = "The characters !@#$%^&*() are not allowed")]
-        [StringLength(55, ErrorMessage = "Please shorten the product title to 55 characters")]
         public string Title { get; set; }
 
         [Required]

--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -21,11 +21,15 @@ namespace Bangazon.Models
         public string Description { get; set; }
 
         [Required]
+        // Billy Mitchell: This Regular Expression is used to forbid users from usings these !@#$%^&*() characters. Use allow: [characters in here] or not allow [^characters in here]
+        [RegularExpression(@"^[^!@#$%^&*()]+$", ErrorMessage = "The characters !@#$%^&*() are not allowed")]
         [StringLength(55, ErrorMessage = "Please shorten the product title to 55 characters")]
         public string Title { get; set; }
 
         [Required]
         [DisplayFormat(DataFormatString = "{0:C}")]
+        //Billy Mitchell: This Data Annotation forbids the user from entering a price higher then 10,000
+        [Range(0.0, 10000.0, ErrorMessage = "Price cannot exceed $10,000")]
         public double Price { get; set; }
 
         [Required]

--- a/Bangazon/Views/Home/Privacy.cshtml
+++ b/Bangazon/Views/Home/Privacy.cshtml
@@ -1,6 +1,30 @@
 ﻿@{
     ViewData["Title"] = "Privacy Policy";
 }
-<h1>@ViewData["Title"]</h1>
 
-<p>Use this page to detail your site's privacy policy.</p>
+<div style="padding: 20px;">
+    <div style="border: 2px solid green; padding: 20px;">
+        <center><strong>Privacy Notice</strong></center>
+        <p>This privacy notice discloses the privacy practices for <span style="text-decoration: underline;">(www.bangazon.com)</span>. This privacy notice applies solely to information collected by this website. It will notify you of the following:</p>
+        <ol type="1">
+            <li>What personally identifiable information is collected from you through the website, how it is used and with whom it may be shared.</li>
+            <li>What choices are available to you regarding the use of your data.</li>
+            <li>The security procedures in place to protect the misuse of your information.</li>
+            <li>How you can correct any inaccuracies in the information.</li>
+        </ol>
+        <p><strong>Information Collection, Use, and Sharing</strong> <br>We are the sole owners of the information collected on this site. We only have access to/collect information that you voluntarily give us via email or other direct contact from you. We will not sell or rent this information to anyone.</p>
+        <p>We will use your information to respond to you, regarding the reason you contacted us. We will not share your information with any third party outside of our organization, other than as necessary to fulfill your request, e.g. to ship an order.</p>
+        <p>Unless you ask us not to, we may contact you via email in the future to tell you about specials, new products or services, or changes to this privacy policy.</p>
+        <p><strong>Your Access to and Control Over Information</strong> <br>You may opt out of any future contacts from us at any time. You can do the following at any time by contacting us via the email address or phone number given on our website:</p>
+        <ul>
+            <li>See what data we have about you, if any.</li>
+            <li>Change/correct any data we have about you.</li>
+            <li>Have us delete any data we have about you.</li>
+            <li>Express any concern you have about our use of your data.</li>
+        </ul>
+        <p><strong>Security</strong> <br>We take precautions to protect your information. When you submit sensitive information via the website, your information is protected both online and offline.</p>
+        <p>Wherever we collect sensitive information (such as credit card data), that information is encrypted and transmitted to us in a secure way. You can verify this by looking for a lock icon in the address bar and looking for "https" at the beginning of the address of the Web page.</p>
+        <p>While we use encryption to protect sensitive information transmitted online, we also protect your information offline. Only employees who need the information to perform a specific job (for example, billing or customer service) are granted access to personally identifiable information. The computers/servers in which we store personally identifiable information are kept in a secure environment.</p>
+        <p><strong>If you feel that we are not abiding by this privacy policy, you should contact us immediately via telephone at <span style="text-decoration: underline;">800-867-5309</span> or <span style="text-decoration: underline;">support@bangazon.com</span>.</strong></p>
+    </div>
+</div>


### PR DESCRIPTION
# Description

This pull request is for restricting the product price to 10K and these characters !@#$%^&*() can not be used in title or description when creating a product.

Fixes Issue # [12](https://github.com/the-devastating-chickens/BangazonSite/issues/12) &  [13](https://github.com/the-devastating-chickens/BangazonSite/issues/13)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

1. `git fetch --all`
1. `git checkout wem-maxProductPrice-1`
1. Review code
1. Run app and check for build errors
1. Click sell a product on the navigation bar
1. Attempt to add any of these characters !@#$%^&*() to the product title or product description. Make sure you are provided an error message and are not allowed to add the product.
1. Attempt to enter a price higher than 10k and make sure you are provided an error message and that it won't allow you to the product if the price is over 10k
1. Click the privacy link on the navigation bar and make sure you are displayed a privacy notice. 



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
