### PR TITLE
WEM Order History Feature

### DIFF
--- a/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
@@ -12,4 +12,5 @@
         <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication">Two-factor authentication</a></li>
         <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData">Personal data</a></li>
         <li class="nav-item"><a class="nav-link" id="payment-types" asp-controller="PaymentTypes" asp-action="Index">See Payment Types</a></li>
+        <li class="nav-item"><a class="nav-link" id="orders" asp-controller="Orders" asp-action="Index">OrderHistory</a></li>
     </ul>

--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -28,7 +28,8 @@ namespace Bangazon.Controllers
         // GET: Orders
         public async Task<IActionResult> Index()
         {
-            var applicationDbContext = _context.Order.Include(o => o.PaymentType).Include(o => o.User);
+            var currentUser = await _userManager.GetUserAsync(HttpContext.User);
+            var applicationDbContext = _context.Order.Include(o => o.PaymentType).Include(o => o.User).Where(o => o.UserId == currentUser.Id);
             return View(await applicationDbContext.ToListAsync());
         }
 

--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -23,16 +23,17 @@ namespace Bangazon.Controllers
             _userManager = userManager;
         }
 
-        private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
+        //private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
 
+        // Modified by Billy Mitchell. This controller pull all previous orders and current cart that are only associated with the currently logged in user.
         // GET: Orders
         public async Task<IActionResult> Index()
         {
             var currentUser = await _userManager.GetUserAsync(HttpContext.User);
-            var applicationDbContext = _context.Order.Include(o => o.PaymentType).Include(o => o.User).Where(o => o.UserId == currentUser.Id);
+            var applicationDbContext = _context.Order.Include(o => o.PaymentType).Include(o => o.User).Where(o => o.UserId == currentUser.Id && o.PaymentType != null);
             return View(await applicationDbContext.ToListAsync());
         }
-
+        
         //Modified by Anne Vick. Now gets a list of orderProducts associated with the order's orderId.
         // GET: Orders/Details/5
         public async Task<IActionResult> Details(int? id)

--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -55,14 +55,20 @@ namespace Bangazon.Controllers
             var orderProducts = await _context.OrderProduct
                 .Where(o => o.OrderId == id).ToListAsync();
 
+            var OrdertTotal = 0.0;
+
            //get the Product for each orderProduct.
            foreach (var item in orderProducts)
             {
                 item.Product = await _context.Product.FirstOrDefaultAsync(p => p.ProductId == item.ProductId);
+                OrdertTotal += item.Product.Price;
             }
-
+           
             //Add the list of orderProducts to the order.
             order.OrderProducts = orderProducts;
+
+            //Adding the price of each product together.
+            order.OrderTotal = OrdertTotal;
 
             return View(order);
         }

--- a/Bangazon/Models/Order.cs
+++ b/Bangazon/Models/Order.cs
@@ -27,6 +27,8 @@ namespace Bangazon.Models
 
     public int? PaymentTypeId {get;set;}
     public PaymentType PaymentType {get;set;}
+    [NotMapped]
+    public double OrderTotal { get; set; }
 
     public virtual ICollection<OrderProduct> OrderProducts { get; set; }
   }

--- a/Bangazon/Views/Orders/Details.cshtml
+++ b/Bangazon/Views/Orders/Details.cshtml
@@ -21,12 +21,18 @@
         </dt>
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.DateCompleted)
-        </dd>                
+        </dd>
         <dt class="col-sm-2">
             Payment Type
         </dt>
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.PaymentType.AccountNumber)
+        </dd>
+        <dt class="col-sm-2">
+            Order Total
+        </dt>
+        <dd class="col-sm-10">
+            $@Html.DisplayFor(model => model.OrderTotal)
         </dd>
         <dt class="col-sm-2">
             Products Ordered
@@ -35,7 +41,7 @@
             @foreach (var item in Model.OrderProducts)
             {
                 <div>
-                    @item.Product.Title
+                    @item.Product.Title $@item.Product.Price
                     <hr />
                 </div>
             }

--- a/Bangazon/Views/Orders/Details.cshtml
+++ b/Bangazon/Views/Orders/Details.cshtml
@@ -49,7 +49,6 @@
 
     </dl>
 </div>
-<div>
-    <a asp-action="Edit" asp-route-id="@Model.OrderId">Edit</a> |
+<div>    
     <a asp-action="Index">Back to List</a>
 </div>

--- a/Bangazon/Views/Orders/Details.cshtml
+++ b/Bangazon/Views/Orders/Details.cshtml
@@ -11,31 +11,25 @@
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.DateCreated)
+            Date Created
         </dt>
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.DateCreated)
         </dd>
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.DateCompleted)
+            Date Completed
         </dt>
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.DateCompleted)
-        </dd>
+        </dd>                
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.User)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.User.Id)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.PaymentType)
+            Payment Type
         </dt>
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.PaymentType.AccountNumber)
         </dd>
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.OrderProducts)
+            Products Ordered
         </dt>
         <dd class="col-sm-10">
             @foreach (var item in Model.OrderProducts)

--- a/Bangazon/Views/Orders/Edit.cshtml
+++ b/Bangazon/Views/Orders/Edit.cshtml
@@ -17,12 +17,7 @@
                 <label asp-for="DateCompleted" class="control-label"></label>
                 <input asp-for="DateCompleted" class="form-control" />
                 <span asp-validation-for="DateCompleted" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="UserId" class="control-label"></label>
-                <select asp-for="UserId" class="form-control" asp-items="ViewBag.UserId"></select>
-                <span asp-validation-for="UserId" class="text-danger"></span>
-            </div>
+            </div>            
             <div class="form-group">
                 <label asp-for="PaymentTypeId" class="control-label"></label>
                 <select asp-for="PaymentTypeId" class="form-control" asp-items="ViewBag.PaymentTypeId"></select>

--- a/Bangazon/Views/Orders/Index.cshtml
+++ b/Bangazon/Views/Orders/Index.cshtml
@@ -13,16 +13,16 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.DateCreated)
+                Order #
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.DateCompleted)
+                Date Created
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.User)
+                Date Completed
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.PaymentType)
+                Payment Type
             </th>
             <th></th>
         </tr>
@@ -31,21 +31,19 @@
 @foreach (var item in Model) {
         <tr>
             <td>
+                @Html.DisplayFor(modelItem => item.OrderId)
+            </td>
+            <td>
                 @Html.DisplayFor(modelItem => item.DateCreated)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.DateCompleted)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.User.Id)
-            </td>
-            <td>
                 @Html.DisplayFor(modelItem => item.PaymentType.AccountNumber)
             </td>
-            <td>
-                <a asp-action="Edit" asp-route-id="@item.OrderId">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.OrderId">Details</a> |
-                <a asp-action="Delete" asp-route-id="@item.OrderId">Delete</a>
+            <td>              
+                <a asp-action="Details" asp-route-id="@item.OrderId">Order Details</a>               
             </td>
         </tr>
 }

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -42,7 +42,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Products" asp-action="MyIndex">My Products</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">View Cart</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Orders" asp-action="ViewCart">View Cart</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>


### PR DESCRIPTION
# Description

This pull request is for the Order History feature that gives the user the ability to see all previous orders, and when clicking on a previous order, they are able to see the details for the order that includes all the products ordered, the price of each product and the total of all the products ordered.

Fixes Issue # [15](https://github.com/the-devastating-chickens/BangazonSite/issues/15)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Testing Instructions

1. `git checkout master`
1. `git fetch --all`
1. `git checkout wem-orderHistory-2`
1. review code
1. click on the my settings link in the top right of the nav bar
1. click order history
1. check that only previous orders are show(orders that have been completed)
1. click details next to an order and make sure all the products that are associated with that order are show with the price of each product.
1. make sure the total of all the products that were associated with the order is displayed. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
