### PR TITLE
Av view cart

### DIFF
--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -43,14 +43,29 @@ namespace Bangazon.Controllers
             {
                 //get a list of all orders from db.
                 List<Order> orders = await _context.Order.ToListAsync();
-                //find order that matches the user Id and has no date completed.
+                //find order that matches the user Id and has no payment type associated with it.
                 Order currentOrder = orders.Find(o => o.UserId == currentUser.Id && o.PaymentTypeId == null);
 
+                //if current order is found, return it in the view.
                 if (currentOrder != null)
                 {
+                    var currentOrderProducts = await _context.OrderProduct
+                        .Where(op => op.OrderId == currentOrder.OrderId).ToListAsync();
+
+                    //get the Product for each orderProduct.
+                    foreach (var item in currentOrderProducts)
+                    {
+                        item.Product = await _context.Product.FirstOrDefaultAsync(p => p.ProductId == item.ProductId);
+                    }
+
+                    //Add the list of orderProducts to the order.
+                    currentOrder.OrderProducts = currentOrderProducts;
+
                     return View(currentOrder);
+
                 } else
                 {
+                    //if not found, creates a new order by calling the order create method and returning the IActionResult as its own result.
                     Order newOrder = new Order();
                     return await this.Create(newOrder);
                 }

--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -23,7 +23,7 @@ namespace Bangazon.Controllers
             _userManager = userManager;
         }
 
-        //private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
+        private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
 
         // Modified by Billy Mitchell. This controller pull all previous orders and current cart that are only associated with the currently logged in user.
         // GET: Orders
@@ -54,14 +54,19 @@ namespace Bangazon.Controllers
                     var currentOrderProducts = await _context.OrderProduct
                         .Where(op => op.OrderId == currentOrder.OrderId).ToListAsync();
 
+                    var currentOrderTotal = 0.0;
+
                     //get the Product for each orderProduct.
                     foreach (var item in currentOrderProducts)
                     {
                         item.Product = await _context.Product.FirstOrDefaultAsync(p => p.ProductId == item.ProductId);
+                        currentOrderTotal += item.Product.Price;
                     }
 
                     //Add the list of orderProducts to the order.
                     currentOrder.OrderProducts = currentOrderProducts;
+                    //add total
+                    currentOrder.OrderTotal = currentOrderTotal;
 
                     return View(currentOrder);
                 } else

--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -62,7 +62,6 @@ namespace Bangazon.Controllers
                     currentOrder.OrderProducts = currentOrderProducts;
 
                     return View(currentOrder);
-
                 } else
                 {
                     //if not found, creates a new order by calling the order create method and returning the IActionResult as its own result.
@@ -75,6 +74,7 @@ namespace Bangazon.Controllers
                 .Include(o => o.PaymentType)
                 .Include(o => o.User)
                 .FirstOrDefaultAsync(m => m.OrderId == id);
+
             if (order == null)
             {
                 return NotFound();

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -42,7 +42,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Products" asp-action="MyIndex">My Products</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">View Cart</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Orders" asp-action="Details">View Cart</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>


### PR DESCRIPTION
# Description
The user can now view their cart. Current cart is always the order belonging to that user which does not have a payment type assigned to it. If there is not an order belonging to that user which does not have a payment type assigned to it, one is created and the user is redirected to view that empty cart.

Fixes Issue # (link issue ticket here)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
For the best testing environment, try deleting any table containing an uncompleted order for your user account (or adding a payment type to any uncompleted orders).
git fetch --all
git checkout av-view-cart
start program
Click "View Cart"
A new order should be created and displayed if none exists.
Add an item to an order.
Click "View Cart" again.
The cart that displays should be that order, displaying the item you just added.



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works
